### PR TITLE
feat: 버튼 시스템 컴포넌트 추가

### DIFF
--- a/src/components/Button.jsx
+++ b/src/components/Button.jsx
@@ -1,0 +1,96 @@
+import { forwardRef } from 'react';
+import { Link } from 'react-router-dom';
+import styled, { css } from 'styled-components';
+import { colors } from '@/styles/constants';
+import { darkenHex, hexToRGB } from '@/styles/utils';
+
+const Button = forwardRef(
+  (
+    {
+      className,
+      type = 'button',
+      variant = 'default',
+      size = 'default',
+      fullWidth = false,
+      rounded = false,
+      href,
+      ...props
+    },
+    ref
+  ) => {
+    const Comp = href ? StyledLink : StyledButton;
+    return (
+      <Comp
+        className={className}
+        $variant={variant}
+        $size={size}
+        $fullWidth={fullWidth}
+        $rounded={rounded}
+        type={type}
+        ref={ref}
+        {...props}
+      />
+    );
+  }
+);
+
+const baseStyles = css`
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  white-space: nowrap;
+  border-radius: 8px;
+  font-size: 14px;
+  font-weight: 500;
+  transition: 0.15s ease-in-out;
+`;
+
+const variantStyles = {
+  default: css`
+    background-color: var(--color-primary);
+    color: var(--color-primary-foreground);
+    &:hover {
+      background-color: ${hexToRGB(colors.primary, 0.9)};
+    }
+  `,
+  secondary: css`
+    background-color: var(--color-secondary);
+    color: var(--color-secondary-foreground);
+    font-weight: bold;
+    &:hover {
+      background-color: ${darkenHex(colors.secondary, 10)};
+    }
+  `
+};
+
+const sizeStyles = {
+  default: css`
+    height: 40px;
+    padding: 10px 24px;
+  `,
+  medium: css`
+    height: 48px;
+    padding: 12px 24px;
+    font-size: 15px;
+  `
+};
+
+const StyledButton = styled.button`
+  ${baseStyles}
+  ${(props) => variantStyles[props.$variant] || variantStyles.default}
+  ${(props) => sizeStyles[props.$size] || sizeStyles.default}
+  ${(props) => props.$fullWidth && 'width: 100%;'}
+  ${(props) => props.$rounded && 'border-radius: 25px;'}
+`;
+
+const StyledLink = styled(Link)`
+  ${baseStyles}
+  ${(props) => variantStyles[props.$variant] || variantStyles.default}
+  ${(props) => sizeStyles[props.$size] || sizeStyles.default}
+  ${(props) => props.$fullWidth && 'width: 100%;'}
+  ${(props) => props.$rounded && 'border-radius: 25px;'}
+`;
+
+Button.displayName = 'Button';
+
+export { Button };

--- a/src/styles/constants.js
+++ b/src/styles/constants.js
@@ -1,31 +1,23 @@
 import { css } from 'styled-components';
 
 export const colors = {
-  primary: '#0f172a',
+  primary: '#845bfb',
   primaryForeground: '#ffffff',
-  destructive: '#ef4444',
-  destructiveForeground: '#ffffff',
-  secondary: '#f1f5f9',
-  secondaryForeground: '#0f172a',
-  border: '#e2e8f0',
-  muted: '#f1f5f9',
-  mutedForeground: '#64748b',
+  secondary: '#ffffff',
+  secondaryForeground: '#606060',
+  border: '#555555',
   shadow: '#000000',
-  foreground: '#020817',
-  baseBackground: '#ffffff'
+  foreground: '#999999',
+  baseBackground: '#000000'
 };
 
 export const constants = css`
   :root {
     --color-primary: ${colors.primary};
     --color-primary-foreground: ${colors.primaryForeground};
-    --color-destructive: ${colors.destructive};
-    --color-destructive-foreground: ${colors.destructiveForeground};
     --color-secondary: ${colors.secondary};
     --color-secondary-foreground: ${colors.secondaryForeground};
     --color-border: ${colors.border};
-    --color-muted: ${colors.muted};
-    --color-muted-foreground: ${colors.mutedForeground};
     --color-shadow: ${colors.shadow};
     --color-foreground: ${colors.foreground};
     --color-base-background: ${colors.baseBackground};

--- a/src/styles/utils.js
+++ b/src/styles/utils.js
@@ -1,0 +1,43 @@
+import { css } from 'styled-components';
+
+export const ellipsisStyle = (line = 1) => css`
+  overflow: hidden;
+  text-overflow: ellipsis;
+  -webkit-line-clamp: ${line};
+  -webkit-box-orient: vertical;
+  word-wrap: break-word;
+  -webkit-box-sizing: border-box;
+  box-sizing: border-box;
+  display: -webkit-box;
+`;
+
+export const hexToRGB = (hex, alpha) => {
+  const r = parseInt(hex.slice(1, 3), 16);
+  const g = parseInt(hex.slice(3, 5), 16);
+  const b = parseInt(hex.slice(5, 7), 16);
+
+  if (alpha) return `rgba(${r}, ${g}, ${b}, ${alpha})`;
+  return `rgb(${r}, ${g}, ${b})`;
+};
+
+// darkenHex 함수는 주어진 색상(hex)을 지정된 양(amount)만큼 어둡게 변환합니다.
+export const darkenHex = (hex, amount) => {
+  if (hex[0] === '#') {
+    hex = hex.slice(1);
+  }
+
+  // 16진수 문자열을 정수로 변환합니다.
+  const num = parseInt(hex, 16);
+  // 빨간색, 초록색, 파란색 값을 추출하고 amount만큼 감소시킵니다.
+  let r = (num >> 16) - amount;
+  let g = ((num >> 8) & 0x00ff) - amount;
+  let b = (num & 0x0000ff) - amount;
+
+  // 각 색상 값이 0보다 작아지지 않도록 합니다.
+  if (r < 0) r = 0;
+  if (g < 0) g = 0;
+  if (b < 0) b = 0;
+
+  // 어두워진 색상을 16진수 문자열로 변환합니다.
+  return '#' + ((r << 16) | (g << 8) | b).toString(16).padStart(6, '0');
+};


### PR DESCRIPTION
close #8 
<img width="582" alt="image" src="https://github.com/SpartaNBTTeam/newsfeed/assets/40863185/675558af-4c1d-4f89-a615-0f2258ebcc37">
<br/>

## 재 사용 가능한 버튼 시스템 컴포넌트 입니다.

- 기본 타입은 버튼입니다.
- type="link"를 전달해주면, react router dom의 Link 컴포넌트를 사용합니다.

```
<Button size="medium">나의 포트폴리오도 올리기</Button>
```
- size props를 주어 버튼 사이즈를 조정할 수 있습니다.
- 기본 primary 컬러는 purple 입니다.

```
<Button variant="secondary" rounded>
  내 프로필
</Button>
```
- rounded props를 전달해 둥글게 만들 수 있습니다.
